### PR TITLE
Fix format date

### DIFF
--- a/src/vue-tailwind-picker.vue
+++ b/src/vue-tailwind-picker.vue
@@ -491,7 +491,6 @@ export default {
     startDate: {
       type: String,
       required: false,
-      default: dayjs().format('YYYY-MM-DD'),
     },
     endDate: {
       type: String,
@@ -512,7 +511,6 @@ export default {
     formatDate: {
       type: String,
       required: false,
-      default: 'YYYY-MM-DD',
     },
     // Confused with this
     formatDisplay: {
@@ -579,7 +577,7 @@ export default {
     },
   },
   data() {
-    const startDatepicker = dayjs(this.startDate, this.formatDate)
+    const startDatepicker = this.startDate ? dayjs(this.startDate, this.formatDate) : dayjs()
     // Featured for my own project
     //   .add(
     //   dayjs().hour() >= 20 ? 1 : 0,

--- a/src/vue-tailwind-picker.vue
+++ b/src/vue-tailwind-picker.vue
@@ -511,6 +511,7 @@ export default {
     formatDate: {
       type: String,
       required: false,
+      default: 'YYYY-MM-DD',
     },
     // Confused with this
     formatDisplay: {


### PR DESCRIPTION
## Problem
Because of the default value of the `startDate` prop it's not possible to use the `formatDate` prop without overriding the `startDate` every time. 
```
startDate: {
      type: String,
      required: false,
      default: dayjs().format('YYYY-MM-DD'), // hardcoded format does not respect the formatDate prop
    },
```

## Solution
I removed the default value which is using a hardcoded format and added a `today fallback` for the initialization of the `startDatepicker` variable instead.